### PR TITLE
Upgrade to resolve deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/nkbt/react-motion-loop",
   "peerDependencies": {
+    "prop-types": "15.5.9",
     "react": "^0.14 || ^15",
     "react-motion": "^0.5"
   },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   },
   "devDependencies": {
     "react-component-template": "0.1.10",
-    "react-motion": "0.4.5"
+    "react-motion": "0.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/nkbt/react-motion-loop",
   "peerDependencies": {
     "react": "^0.14 || ^15",
-    "react-motion": "^0.4"
+    "react-motion": "^0.5"
   },
   "devDependencies": {
     "react-component-template": "0.1.10",

--- a/src/Component.js
+++ b/src/Component.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Motion} from 'react-motion';
+import PropTypes from 'prop-types';
 
 export class ReactMotionLoop extends React.Component {
   constructor(props) {
@@ -41,6 +42,6 @@ export class ReactMotionLoop extends React.Component {
 }
 
 ReactMotionLoop.propTypes = {
-  styleFrom: React.PropTypes.object.isRequired,
-  styleTo: React.PropTypes.object.isRequired
+  styleFrom: PropTypes.object.isRequired,
+  styleTo: PropTypes.object.isRequired
 };

--- a/src/Component.js
+++ b/src/Component.js
@@ -1,26 +1,24 @@
 import React from 'react';
 import {Motion} from 'react-motion';
 
+export class ReactMotionLoop extends React.Component {
+  constructor(props) {
+    super(props);
 
-export const ReactMotionLoop = React.createClass({
-  propTypes: {
-    styleFrom: React.PropTypes.object.isRequired,
-    styleTo: React.PropTypes.object.isRequired
-  },
+    this.onRest = this.onRest.bind(this);
 
-  getInitialState() {
-    return {flag: true};
-  },
+    this.state = {flag: true};
+  }
 
 
   componentWillUnmount() {
     cancelAnimationFrame(this.raf);
-  },
+  }
 
 
   onRest() {
     this.raf = requestAnimationFrame(() => this.setState({flag: !this.state.flag}));
-  },
+  }
 
 
   render() {
@@ -40,6 +38,9 @@ export const ReactMotionLoop = React.createClass({
         {...props} />
     );
   }
-});
+}
 
-
+ReactMotionLoop.propTypes = {
+  styleFrom: React.PropTypes.object.isRequired,
+  styleTo: React.PropTypes.object.isRequired
+};


### PR DESCRIPTION
- Update `react-motion` dependencies
- Convert `React.createClass` to ES6 class
- Replace deprecated `React.PropTypes` with recommended `prop-types` package